### PR TITLE
[Feat] 챗봇화면 헤드라인 배너 API 연동

### DIFF
--- a/src/app/(withHeader)/chatbot/page.tsx
+++ b/src/app/(withHeader)/chatbot/page.tsx
@@ -13,25 +13,21 @@ import Image from 'next/image';
 import logo from '@/assets/logo.png';
 import { useToastStore } from '@/stores/toastStore';
 import HeadlineBanner from '@/components/chatbot/HeadlineBanner';
-import { Headline } from '@/types/common/headline';
 import { usePostChatbotQuestion } from '@/queries/chatbot/usePostChatbotQuestion';
+import { useHeadlineData } from '@/hooks/useGetHeadLine';
+import HeadlineBannerSkeleton from '@/components/chatbot/HeadlineBannerSkeleton';
 
 const suggestQuestions: string[] = [
   "휴가 신청하는 법을 알려줘.",
   "유료 구독료 지원 일정을 알려줘."
 ]
 
-const dummyHeadlines: Headline[] = [
-  { type: 'notice', title: '시스템 점검 안내: 5월 3일 오전 2시~4시', id: 1 },
-  { type: 'news', title: '춘이네 비서실 봄맞이 새 기능 업데이트!', id: 1 },
-  { type: 'notice', title: '개인정보 처리방침 변경 안내', id: 2 },
-  { type: 'news', title: '5월 황금연휴 특별 이벤트 안내', id: 2 },
-];
-
 export default function ChatbotPage() {
   const [chats, setChats] = useState<ChatMessage[]>([]);
   const [currentInput, setCurrentInput] = useState('');
-  const [headlines, setHeadlines] = useState<Headline[]>(dummyHeadlines);
+  // 상단 헤드라인 배너 가져오기
+  const { headlines, isLoading: isHeadlineLoading } = useHeadlineData();
+
   const { mutateAsync: postQuestion, isPending } = usePostChatbotQuestion()
 
   const { showToast } = useToastStore();
@@ -95,7 +91,8 @@ export default function ChatbotPage() {
   return (
     <div className="flex flex-col min-h-app bg-gray-50">
       {/* 최신 공지와 뉴스 */}
-      {chats.length === 0 && headlines.length > 0 && (
+      {isHeadlineLoading && chats.length === 0 && <HeadlineBannerSkeleton/>}
+      {!isHeadlineLoading && chats.length === 0 && headlines.length > 0 && (
         <HeadlineBanner items={headlines}/>
       )}
 

--- a/src/components/chatbot/HeadlineBannerSkeleton.tsx
+++ b/src/components/chatbot/HeadlineBannerSkeleton.tsx
@@ -1,15 +1,12 @@
+import SkeletonBox from '@/components/common/SkeletonBox';
+
 export default function HeadlineBannerSkeleton() {
   return (
     <div className="bg-white mx-4 mt-4 rounded-xl shadow-sm overflow-hidden animate-pulse">
       <div className="h-12 px-4 flex items-center space-x-3">
-        {/* 아이콘 */}
-        <div className="w-6 h-6 rounded-full bg-gray-300 flex-shrink-0" />
-
-        {/* 텍스트 */}
-        <div className="flex-1 h-4 bg-gray-200 rounded" />
-
-        {/* 인덱스 */}
-        <div className="w-10 h-3 bg-gray-200 rounded" />
+        <SkeletonBox className="w-6 h-6 rounded-full flex-shrink-0" />
+        <SkeletonBox className="flex-1 h-4" />
+        <SkeletonBox className="w-10 h-3" />
       </div>
     </div>
   );

--- a/src/components/chatbot/HeadlineBannerSkeleton.tsx
+++ b/src/components/chatbot/HeadlineBannerSkeleton.tsx
@@ -1,0 +1,16 @@
+export default function HeadlineBannerSkeleton() {
+  return (
+    <div className="bg-white mx-4 mt-4 rounded-xl shadow-sm overflow-hidden animate-pulse">
+      <div className="h-12 px-4 flex items-center space-x-3">
+        {/* 아이콘 */}
+        <div className="w-6 h-6 rounded-full bg-gray-300 flex-shrink-0" />
+
+        {/* 텍스트 */}
+        <div className="flex-1 h-4 bg-gray-200 rounded" />
+
+        {/* 인덱스 */}
+        <div className="w-10 h-3 bg-gray-200 rounded" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/SkeletonBox.tsx
+++ b/src/components/common/SkeletonBox.tsx
@@ -1,0 +1,14 @@
+import React, { HTMLAttributes } from 'react';
+
+interface SkeletonBoxProps extends HTMLAttributes<HTMLDivElement> {
+  className?: string;
+}
+
+export default function SkeletonBox({ className = '', ...props }: SkeletonBoxProps) {
+  return (
+    <div
+      className={`bg-gray-200 rounded animate-pulse ${className}`}
+      {...props}
+    />
+  );
+}

--- a/src/hooks/useGetHeadLine.ts
+++ b/src/hooks/useGetHeadLine.ts
@@ -1,0 +1,26 @@
+import { useNewsListQuery } from '@/queries/news/useNewsListQuery';
+import { useNoticeListInfinityQuery } from '@/queries/post/useNoticeListInfinityQuery';
+import { Headline } from '@/types/common/headline';
+
+export const useHeadlineData = () => {
+  const { data: news, isLoading: isLoadingNews } = useNewsListQuery('latest', 2);
+  const { data: notices, isLoading: isLoadingNotices } = useNoticeListInfinityQuery(2);
+
+  const isLoading = isLoadingNews || isLoadingNotices;
+
+  const headlines = [
+    ...(news?.map((item): Headline => ({
+      type: 'news',
+      title: item.title,
+      id: item.id,
+    })) ?? []),
+
+    ...(notices?.map((item): Headline => ({
+      type: 'notice',
+      title: item.title,
+      id: item.id,
+    })) ?? []),
+  ];
+
+  return { headlines, isLoading };
+};


### PR DESCRIPTION
### Description
- 챗봇 화면 상단의 헤드라인 배너 컴포넌트에 최신 뉴스/공지 각 2개씩 가져오도록 구현

### Related Issues
- Closes #33

### Changes Made
1. 헤드라인 가져오는 API 연동
2. 공통 Skeleton을 위한 SkeletonBox 컴포넌트 구현
