### PR TITLE
Refactor: 게시글(공지/뉴스) 상세 페이지를 Server side에서 렌더링 하도록 수정

### DIFF
--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -14,6 +14,8 @@ export async function fetcher<T>(url: string, options?: RequestInit): Promise<T>
     signal: AbortSignal.timeout(timeout),
   });
 
+  const responseBody = await res.json();
+
   if (res.status === 401) {
     useUserPersistStore.getState().cleanUser();
     useToastStore.getState().showToast(errors.UNAUTHORIZED, 'error');
@@ -23,17 +25,12 @@ export async function fetcher<T>(url: string, options?: RequestInit): Promise<T>
   } else if (!res.ok) {
     let message = errors.DEFAULT;
 
-    try {
-      const errorBody = await res.json();
-      if (typeof errorBody?.message === 'string') {
-        message = errorBody.message;
-      }
-    } catch (e) {
-      console.error(e);
+    if (typeof responseBody?.message === 'string') {
+      message = responseBody.message;
     }
 
     useToastStore.getState().showToast(message, 'error');
   }
 
-  return res.json();
+  return responseBody;
 }

--- a/src/app/(withHeader)/news/[id]/page.tsx
+++ b/src/app/(withHeader)/news/[id]/page.tsx
@@ -1,69 +1,20 @@
 'use client';
 
-import { ArrowUp, Heart, MessageCircle } from 'lucide-react';
 import { useParams } from 'next/navigation';
 
-import { FormEvent, useState } from 'react';
-
-import Button from '@/components/common/Button';
-import Input from '@/components/common/Input';
-import LoadingIndicator from '@/components/common/LoadingIndicator';
 import MarkdownViewer from '@/components/common/MarkdownViewer';
 import SingleImage from '@/components/common/SingleImage';
-import PostCommentItem from '@/components/post/PostCommentItem';
+import PostCommentForm from '@/components/post/PostCommentForm';
+import PostCommentList from '@/components/post/PostCommentList';
 import PostHeader from '@/components/post/PostHeader';
+import PostLikeButton from '@/components/post/PostLikeButton';
 import PostSummary from '@/components/post/PostSummary';
-import { useInfiniteScrollObserver } from '@/hooks/useInfiniteScrollObserver';
-import { useCreateNewsCommentMutation } from '@/queries/news/useCreateNewsCommentMutation';
-import { useDeleteNewsCommentMutation } from '@/queries/news/useDeleteNewsCommentMutation';
-import { useNewsCommentListInfinityQuery } from '@/queries/news/useNewsCommentListInfinityQuery';
 import { useNewsDetailQuery } from '@/queries/news/useNewsDetailQuery';
-import { useToggleNewsLikeMutation } from '@/queries/news/useToggleNewsLikeMutation';
-import { useModal } from '@/stores/modalStore';
+import { PostTypes } from '@/types/post/postType';
 
 export default function NewsDetailPage() {
   const params = useParams<{ id: string }>();
   const { data: news } = useNewsDetailQuery(params.id);
-  const { mutate: toggleLike } = useToggleNewsLikeMutation();
-  const { mutate: postComment } = useCreateNewsCommentMutation();
-  const { mutate: deleteComment } = useDeleteNewsCommentMutation();
-  const { data: comments, fetchNextPage, hasNextPage, isFetchingNextPage } = useNewsCommentListInfinityQuery(params.id);
-  const loadingRef = useInfiniteScrollObserver({
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  });
-
-  const { openModal, closeModal } = useModal();
-
-  const [comment, setComment] = useState('');
-
-  const handleSubmitComment = (e: FormEvent) => {
-    e.preventDefault();
-    postComment({ newsId: params.id, content: comment });
-    setComment('');
-  };
-
-  // 댓글 삭제 버튼 클릭 시
-  const handleDeleteComment = (commentId: number) => {
-    openModal(
-      '댓글을 삭제하시겠어요?',
-      <div className="flex justify-end gap-2">
-        <Button variant="ghost" onClick={closeModal}>
-          취소
-        </Button>
-        <Button
-          variant="destructive"
-          onClick={() => {
-            deleteComment({ newsId: params.id, commentId: commentId.toString() });
-            closeModal();
-          }}
-        >
-          삭제
-        </Button>
-      </div>,
-    );
-  };
 
   if (!news) return null;
 
@@ -80,43 +31,11 @@ export default function NewsDetailPage() {
           <SingleImage imageUrl={news.imageUrl} />
         </div>
 
-        {/* 좋아요 버튼 */}
-        <div className="px-4 mb-4 flex justify-center">
-          <Button
-            variant="plain"
-            onClick={() => toggleLike({ newsId: params.id })}
-            className={`flex items-center justify-center px-6 py-2 rounded-full ${news.userLike ? 'bg-secondary-50 text-secondary-400' : 'bg-gray-100 text-gray-500'} transition-all`}
-          >
-            <Heart size={16} className={`mr-2 ${news.userLike ? 'fill-secondary-500 text-secondary-400' : ''}`} />
-            <span className="font-medium">{news.likeCount}</span>
-          </Button>
-        </div>
+        <PostLikeButton type={PostTypes.News} postId={news.id} userLike={news.userLike} likeCount={news.likeCount} />
 
-        {/* 댓글 */}
-        <div className="px-4 py-3 border-t border-gray-100 flex flex-col justify-between items-start gap-3">
-          <div className="flex items-center text-gray-500">
-            <MessageCircle size={16} className="mr-1" />
-            <span className="text-sm font-medium">댓글 {news.commentCount}</span>
-          </div>
+        <PostCommentForm type={PostTypes.News} postId={news.id} commentCount={news.commentCount} />
 
-          <form onSubmit={handleSubmitComment} className="flex w-full gap-3 justify-center items-center">
-            <Input className="flex-1 rounded-xl" value={comment} onChange={(e) => setComment(e.target.value)} />
-
-            <Button variant="outline" size="icon" className="shrink-0" type="submit">
-              <ArrowUp size={18} />
-            </Button>
-          </form>
-        </div>
-
-        {/* 댓글 부분 */}
-        <div className="border-t border-gray-100">
-          {comments &&
-            comments.map((comment) => (
-              <PostCommentItem comment={comment} key={comment.id} onDelete={handleDeleteComment} />
-            ))}
-        </div>
-
-        <LoadingIndicator loadingRef={loadingRef} hasNextPage={hasNextPage} isFetchingNextPage={isFetchingNextPage} />
+        <PostCommentList type={PostTypes.News} postId={news.id} />
       </div>
     </div>
   );

--- a/src/app/(withHeader)/news/[id]/page.tsx
+++ b/src/app/(withHeader)/news/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from 'next/headers';
 
+import { fetcher } from '@/api/fetcher';
 import MarkdownViewer from '@/components/common/MarkdownViewer';
 import SingleImage from '@/components/common/SingleImage';
 import PostCommentForm from '@/components/post/PostCommentForm';
@@ -21,16 +22,14 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
   let news: NewsDetail | null = null;
 
   try {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/v1/news/${id}`, {
+    const { data } = await fetcher<BaseResponse<NewsDetail>>(`/v1/news/${id}`, {
       method: 'GET',
       headers: {
-        'Content-Type': 'application/json',
         Cookie: cookie,
       },
     });
 
-    const { code, data }: BaseResponse<NewsDetail> = await res.json();
-    if (code === 200 && data) news = data;
+    if (data) news = data;
   } catch (e) {
     console.error('fetch failed:', e);
   }

--- a/src/app/(withHeader)/news/[id]/page.tsx
+++ b/src/app/(withHeader)/news/[id]/page.tsx
@@ -1,6 +1,4 @@
-'use client';
-
-import { useParams } from 'next/navigation';
+import { cookies } from 'next/headers';
 
 import MarkdownViewer from '@/components/common/MarkdownViewer';
 import SingleImage from '@/components/common/SingleImage';
@@ -9,12 +7,33 @@ import PostCommentList from '@/components/post/PostCommentList';
 import PostHeader from '@/components/post/PostHeader';
 import PostLikeButton from '@/components/post/PostLikeButton';
 import PostSummary from '@/components/post/PostSummary';
-import { useNewsDetailQuery } from '@/queries/news/useNewsDetailQuery';
+import { BaseResponse } from '@/types/common/base';
+import { NewsDetail } from '@/types/post/newsDetail';
 import { PostTypes } from '@/types/post/postType';
 
-export default function NewsDetailPage() {
-  const params = useParams<{ id: string }>();
-  const { data: news } = useNewsDetailQuery(params.id);
+interface NewsDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
+  const cookie = (await cookies()).toString();
+  const { id } = await params;
+  let news: NewsDetail | null = null;
+
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/v1/news/${id}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: cookie,
+      },
+    });
+
+    const { code, data }: BaseResponse<NewsDetail> = await res.json();
+    if (code === 200 && data) news = data;
+  } catch (e) {
+    console.error('fetch failed:', e);
+  }
 
   if (!news) return null;
 

--- a/src/app/(withHeader)/notices/[id]/page.tsx
+++ b/src/app/(withHeader)/notices/[id]/page.tsx
@@ -1,74 +1,21 @@
 'use client';
 
-import { ArrowUp, Heart, MessageCircle } from 'lucide-react';
 import { useParams } from 'next/navigation';
 
-import { FormEvent, useState } from 'react';
-
-import Button from '@/components/common/Button';
 import ImageCarousel from '@/components/common/ImageCarousel';
-import Input from '@/components/common/Input';
-import LoadingIndicator from '@/components/common/LoadingIndicator';
 import MarkdownViewer from '@/components/common/MarkdownViewer';
-import PostCommentItem from '@/components/post/PostCommentItem';
+import PostCommentForm from '@/components/post/PostCommentForm';
+import PostCommentList from '@/components/post/PostCommentList';
 import PostFileItem from '@/components/post/PostFileItem';
 import PostHeader from '@/components/post/PostHeader';
+import PostLikeButton from '@/components/post/PostLikeButton';
 import PostSummary from '@/components/post/PostSummary';
-import { useInfiniteScrollObserver } from '@/hooks/useInfiniteScrollObserver';
-import { useCreateNoticeCommentMutation } from '@/queries/post/useCreateNoticeCommentMutation';
-import { useDeleteNoticeCommentMutation } from '@/queries/post/useDeleteNoticeCommentMutation';
-import { useNoticeCommentListInfinityQuery } from '@/queries/post/useNoticeCommentListInfinityQuery';
 import { useNoticeDetailQuery } from '@/queries/post/useNoticeDetailQuery';
-import { useToggleNoticeLikeMutation } from '@/queries/post/useToggleNoticeLikeMutation';
-import { useModal } from '@/stores/modalStore';
+import { PostTypes } from '@/types/post/postType';
 
 export default function NoticeDetailPage() {
   const params = useParams<{ id: string }>();
   const { data: notice } = useNoticeDetailQuery(params.id);
-  const { mutate: toggleLike } = useToggleNoticeLikeMutation();
-  const { mutate: postComment } = useCreateNoticeCommentMutation();
-  const { mutate: deleteComment } = useDeleteNoticeCommentMutation();
-  const {
-    data: comments,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = useNoticeCommentListInfinityQuery(params.id);
-  const loadingRef = useInfiniteScrollObserver({
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  });
-
-  const { openModal, closeModal } = useModal();
-  const [comment, setComment] = useState('');
-
-  const handleSubmitComment = (e: FormEvent) => {
-    e.preventDefault();
-    postComment({ noticeId: params.id, content: comment });
-    setComment('');
-  };
-
-  // 댓글 삭제 버튼 클릭 시
-  const handleDeleteComment = (commentId: number) => {
-    openModal(
-      '댓글을 삭제하시겠어요?',
-      <div className="flex justify-end gap-2">
-        <Button variant="ghost" onClick={closeModal}>
-          취소
-        </Button>
-        <Button
-          variant="destructive"
-          onClick={() => {
-            deleteComment({ noticeId: params.id, commentId: commentId.toString() });
-            closeModal();
-          }}
-        >
-          삭제
-        </Button>
-      </div>,
-    );
-  };
 
   if (!notice) return null;
 
@@ -101,43 +48,16 @@ export default function NoticeDetailPage() {
             ))}
         </div>
 
-        {/* 좋아요 버튼 */}
-        <div className="px-4 mb-4 flex justify-center">
-          <Button
-            variant="plain"
-            onClick={() => toggleLike({ noticeId: params.id })}
-            className={`flex items-center justify-center px-6 py-2 rounded-full ${notice.userLike ? 'bg-secondary-50 text-secondary-400' : 'bg-gray-100 text-gray-500'} transition-all`}
-          >
-            <Heart size={16} className={`mr-2 ${notice.userLike ? 'fill-secondary-500 text-secondary-400' : ''}`} />
-            <span className="font-medium">{notice.likeCount}</span>
-          </Button>
-        </div>
+        <PostLikeButton
+          type={PostTypes.Notice}
+          postId={notice.id}
+          userLike={notice.userLike}
+          likeCount={notice.likeCount}
+        />
 
-        {/* 댓글 */}
-        <div className="px-4 py-3 border-t border-gray-100 flex flex-col justify-between items-start gap-3">
-          <div className="flex items-center text-gray-500">
-            <MessageCircle size={16} className="mr-1" />
-            <span className="text-sm font-medium">댓글 {notice.commentCount}</span>
-          </div>
+        <PostCommentForm type={PostTypes.Notice} postId={notice.id} commentCount={notice.commentCount} />
 
-          <form onSubmit={handleSubmitComment} className="flex w-full gap-3 justify-center items-center">
-            <Input className="flex-1 rounded-xl" value={comment} onChange={(e) => setComment(e.target.value)} />
-
-            <Button variant="outline" size="icon" className="shrink-0" type="submit">
-              <ArrowUp size={18} />
-            </Button>
-          </form>
-        </div>
-
-        {/* 댓글 부분 */}
-        <div className="border-t border-gray-100">
-          {comments &&
-            comments.map((comment) => (
-              <PostCommentItem comment={comment} key={comment.id} onDelete={handleDeleteComment} />
-            ))}
-        </div>
-
-        <LoadingIndicator loadingRef={loadingRef} hasNextPage={hasNextPage} isFetchingNextPage={isFetchingNextPage} />
+        <PostCommentList type={PostTypes.Notice} postId={notice.id} />
       </div>
     </div>
   );

--- a/src/app/(withHeader)/notices/[id]/page.tsx
+++ b/src/app/(withHeader)/notices/[id]/page.tsx
@@ -1,6 +1,4 @@
-'use client';
-
-import { useParams } from 'next/navigation';
+import { cookies } from 'next/headers';
 
 import ImageCarousel from '@/components/common/ImageCarousel';
 import MarkdownViewer from '@/components/common/MarkdownViewer';
@@ -10,12 +8,33 @@ import PostFileItem from '@/components/post/PostFileItem';
 import PostHeader from '@/components/post/PostHeader';
 import PostLikeButton from '@/components/post/PostLikeButton';
 import PostSummary from '@/components/post/PostSummary';
-import { useNoticeDetailQuery } from '@/queries/post/useNoticeDetailQuery';
+import { BaseResponse } from '@/types/common/base';
+import { NoticeDetail } from '@/types/post/noticeDetail';
 import { PostTypes } from '@/types/post/postType';
 
-export default function NoticeDetailPage() {
-  const params = useParams<{ id: string }>();
-  const { data: notice } = useNoticeDetailQuery(params.id);
+interface NoticeDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function NoticeDetailPage({ params }: NoticeDetailPageProps) {
+  const cookie = (await cookies()).toString();
+  const { id } = await params;
+  let notice: NoticeDetail | null = null;
+
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/v1/notices/${id}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: cookie,
+      },
+    });
+
+    const { code, data }: BaseResponse<NoticeDetail> = await res.json();
+    if (code === 200 && data) notice = data;
+  } catch (e) {
+    console.error('fetch failed:', e);
+  }
 
   if (!notice) return null;
 

--- a/src/app/(withHeader)/notices/[id]/page.tsx
+++ b/src/app/(withHeader)/notices/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from 'next/headers';
 
+import { fetcher } from '@/api/fetcher';
 import ImageCarousel from '@/components/common/ImageCarousel';
 import MarkdownViewer from '@/components/common/MarkdownViewer';
 import PostCommentForm from '@/components/post/PostCommentForm';
@@ -22,16 +23,14 @@ export default async function NoticeDetailPage({ params }: NoticeDetailPageProps
   let notice: NoticeDetail | null = null;
 
   try {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/v1/notices/${id}`, {
+    const { data } = await fetcher<BaseResponse<NoticeDetail>>(`/v1/notices/${id}`, {
       method: 'GET',
       headers: {
-        'Content-Type': 'application/json',
         Cookie: cookie,
       },
     });
 
-    const { code, data }: BaseResponse<NoticeDetail> = await res.json();
-    if (code === 200 && data) notice = data;
+    if (data) notice = data;
   } catch (e) {
     console.error('fetch failed:', e);
   }

--- a/src/components/common/ImageCarousel.tsx
+++ b/src/components/common/ImageCarousel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import Image from 'next/image';
 

--- a/src/components/common/SingleImage.tsx
+++ b/src/components/common/SingleImage.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 
 import { useState } from 'react';

--- a/src/components/post/PostCommentForm.tsx
+++ b/src/components/post/PostCommentForm.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { ArrowUp, MessageCircle } from 'lucide-react';
+
+import { FormEvent, useEffect, useState } from 'react';
+
+import Button from '@/components/common/Button';
+import Input from '@/components/common/Input';
+import { useCreateNewsCommentMutation } from '@/queries/news/useCreateNewsCommentMutation';
+import { useCreateNoticeCommentMutation } from '@/queries/post/useCreateNoticeCommentMutation';
+import { usePostCommentCountStore } from '@/stores/postCommentCountStore';
+import { PostTypes } from '@/types/post/postType';
+
+interface PostCommentFormProps {
+  type: PostTypes;
+  postId: number;
+  commentCount: number;
+}
+
+export default function PostCommentForm({ type, postId, commentCount }: PostCommentFormProps) {
+  const { mutate: postNoticeComment } = useCreateNoticeCommentMutation();
+  const { mutate: postNewsComment } = useCreateNewsCommentMutation();
+
+  const [comment, setComment] = useState('');
+  const { count, set, increment } = usePostCommentCountStore();
+
+  const handleSubmitComment = (e: FormEvent) => {
+    e.preventDefault();
+
+    const payload = { content: comment };
+    const commonOptions = {
+      onSuccess: () => {
+        increment();
+      },
+    };
+
+    if (type === PostTypes.Notice) {
+      postNoticeComment({ noticeId: postId.toString(), ...payload }, commonOptions);
+    } else if (type === PostTypes.News) {
+      postNewsComment({ newsId: postId.toString(), ...payload }, commonOptions);
+    }
+
+    setComment('');
+  };
+
+  useEffect(() => {
+    set(commentCount);
+  }, [commentCount]);
+
+  return (
+    <div className="px-4 py-3 border-t border-gray-100 flex flex-col justify-between items-start gap-3">
+      <div className="flex items-center text-gray-500">
+        <MessageCircle size={16} className="mr-1" />
+        <span className="text-sm font-medium">댓글 {count}</span>
+      </div>
+
+      <form onSubmit={handleSubmitComment} className="flex w-full gap-3 justify-center items-center">
+        <Input className="flex-1 rounded-xl" value={comment} onChange={(e) => setComment(e.target.value)} />
+
+        <Button variant="outline" size="icon" className="shrink-0" type="submit">
+          <ArrowUp size={18} />
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/post/PostCommentList.tsx
+++ b/src/components/post/PostCommentList.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import Button from '@/components/common/Button';
+import LoadingIndicator from '@/components/common/LoadingIndicator';
+import PostCommentItem from '@/components/post/PostCommentItem';
+import { useInfiniteScrollObserver } from '@/hooks/useInfiniteScrollObserver';
+import { useDeleteNewsCommentMutation } from '@/queries/news/useDeleteNewsCommentMutation';
+import { useNewsCommentListInfinityQuery } from '@/queries/news/useNewsCommentListInfinityQuery';
+import { useDeleteNoticeCommentMutation } from '@/queries/post/useDeleteNoticeCommentMutation';
+import { useNoticeCommentListInfinityQuery } from '@/queries/post/useNoticeCommentListInfinityQuery';
+import { useModal } from '@/stores/modalStore';
+import { usePostCommentCountStore } from '@/stores/postCommentCountStore';
+import { PostTypes } from '@/types/post/postType';
+
+interface PostCommentListProps {
+  type: PostTypes;
+  postId: number;
+}
+
+export default function PostCommentList({ type, postId }: PostCommentListProps) {
+  const { mutate: deleteNoticeComment } = useDeleteNoticeCommentMutation();
+  const { mutate: deleteNewsComment } = useDeleteNewsCommentMutation();
+
+  const noticeQuery = useNoticeCommentListInfinityQuery(postId.toString());
+  const newsQuery = useNewsCommentListInfinityQuery(postId.toString());
+
+  const {
+    data: comments,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = type === PostTypes.Notice ? noticeQuery : newsQuery;
+
+  const loadingRef = useInfiniteScrollObserver({
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  });
+
+  const { decrement } = usePostCommentCountStore();
+  const { openModal, closeModal } = useModal();
+
+  // 댓글 삭제 버튼 클릭 시
+  const handleDeleteComment = (commentId: number) => {
+    openModal(
+      '댓글을 삭제하시겠어요?',
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" onClick={closeModal}>
+          취소
+        </Button>
+        <Button
+          variant="destructive"
+          onClick={() => {
+            if (type === PostTypes.Notice) {
+              deleteNoticeComment(
+                { noticeId: postId.toString(), commentId: commentId.toString() },
+                { onSuccess: () => decrement() },
+              );
+            } else if (type === PostTypes.News) {
+              deleteNewsComment(
+                { newsId: postId.toString(), commentId: commentId.toString() },
+                { onSuccess: () => decrement() },
+              );
+            }
+            closeModal();
+          }}
+        >
+          삭제
+        </Button>
+      </div>,
+    );
+  };
+
+  return (
+    <>
+      <div className="border-t border-gray-100">
+        {comments &&
+          comments.map((comment) => (
+            <PostCommentItem comment={comment} key={comment.id} onDelete={handleDeleteComment} />
+          ))}
+      </div>
+
+      <LoadingIndicator loadingRef={loadingRef} hasNextPage={hasNextPage} isFetchingNextPage={isFetchingNextPage} />
+    </>
+  );
+}

--- a/src/components/post/PostLikeButton.tsx
+++ b/src/components/post/PostLikeButton.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { Heart } from 'lucide-react';
+
+import { useState } from 'react';
+
+import Button from '@/components/common/Button';
+import { useToggleNewsLikeMutation } from '@/queries/news/useToggleNewsLikeMutation';
+import { useToggleNoticeLikeMutation } from '@/queries/post/useToggleNoticeLikeMutation';
+import { PostTypes } from '@/types/post/postType';
+
+interface PostLikeButtonProps {
+  type: PostTypes;
+  postId: number;
+  userLike: boolean;
+  likeCount: number;
+}
+
+export default function PostLikeButton({
+  type,
+  postId,
+  userLike: initialUserLike,
+  likeCount: initialLikeCount,
+}: PostLikeButtonProps) {
+  const [userLike, setUserLike] = useState(initialUserLike);
+  const [likeCount, setLikeCount] = useState(initialLikeCount);
+  const { mutate: toggleNoticeLike } = useToggleNoticeLikeMutation();
+  const { mutate: toggleNewsLike } = useToggleNewsLikeMutation();
+
+  const handleToggle = () => {
+    const optimisticUserLike = !userLike;
+    const optimisticLikeCount = likeCount + (userLike ? -1 : 1);
+
+    // 낙관적 UI 적용
+    setUserLike(optimisticUserLike);
+    setLikeCount(optimisticLikeCount);
+
+    const rollback = () => {
+      // 실패 시 롤백
+      setUserLike(userLike);
+      setLikeCount(likeCount);
+    };
+
+    if (type === PostTypes.Notice) {
+      toggleNoticeLike(
+        { noticeId: postId.toString() },
+        {
+          onError: rollback,
+        },
+      );
+    } else if (type === PostTypes.News) {
+      toggleNewsLike(
+        { newsId: postId.toString() },
+        {
+          onError: rollback,
+        },
+      );
+    }
+  };
+
+  return (
+    <div className="px-4 mb-4 flex justify-center">
+      <Button
+        variant="plain"
+        onClick={handleToggle}
+        className={`flex items-center justify-center px-6 py-2 rounded-full ${userLike ? 'bg-secondary-50 text-secondary-400' : 'bg-gray-100 text-gray-500'} transition-all`}
+      >
+        <Heart size={16} className={`mr-2 ${userLike ? 'fill-secondary-500 text-secondary-400' : ''}`} />
+        <span className="font-medium">{likeCount}</span>
+      </Button>
+    </div>
+  );
+}

--- a/src/queries/post/useToggleNoticeLikeMutation.ts
+++ b/src/queries/post/useToggleNoticeLikeMutation.ts
@@ -1,10 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { toggleNoticeLike } from '@/api/post';
-import { queryKeys } from '@/constatns/keys';
-import { queryClient } from '@/queries/base/queryClient';
-import { BaseResponse } from '@/types/common/base';
-import { NoticeDetail } from '@/types/post/noticeDetail';
 
 interface ToggleNoticeLikeRequest {
   noticeId: string;
@@ -13,22 +9,5 @@ interface ToggleNoticeLikeRequest {
 export function useToggleNoticeLikeMutation() {
   return useMutation({
     mutationFn: ({ noticeId }: ToggleNoticeLikeRequest) => toggleNoticeLike(noticeId),
-    // 토글 성공 후 데이터 갱신
-    onSuccess: (_data, variables) => {
-      queryClient.setQueryData(
-        [queryKeys.notice, variables.noticeId],
-        (prev: BaseResponse<NoticeDetail> | undefined) => {
-          if (!prev) return prev;
-          return {
-            ...prev,
-            data: {
-              ...prev.data,
-              userLike: !prev.data.userLike,
-              likeCount: prev.data.userLike ? prev.data.likeCount - 1 : prev.data.likeCount + 1,
-            },
-          };
-        },
-      );
-    },
   });
 }

--- a/src/stores/postCommentCountStore.ts
+++ b/src/stores/postCommentCountStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+export const usePostCommentCountStore = create<{
+  count: number;
+  set: (n: number) => void;
+  increment: () => void;
+  decrement: () => void;
+}>((set) => ({
+  count: 0,
+  set: (n) => set({ count: n }),
+  increment: () => set((state) => ({ count: state.count + 1 })),
+  decrement: () => set((state) => ({ count: Math.max(state.count - 1, 0) })),
+}));

--- a/src/types/post/postType.ts
+++ b/src/types/post/postType.ts
@@ -1,0 +1,4 @@
+export enum PostTypes {
+  Notice,
+  News,
+}


### PR DESCRIPTION
### Description
- 게시글 상세 페이지를 SSR로 전환했습니다.
- 인가가 필요한 기능이라 ISR/SSG는 

### Related Issues
- Resolves #58

### Changes Made
1. 게시글 상세 페이지를 SSR로 전환
2. 공지/뉴스 상세에서 공통으로 사용하는 컴포넌트를 공통 컴포넌트로 리팩토링
3. SSR 전환 후 LCP 13% 개선

