### PR TITLE
Feat: 토큰 리프레시 구현

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -5,7 +5,7 @@ const oauthLogin = async (provider: string) => {
   window.location.href = process.env.NEXT_PUBLIC_API_URL + `/v1/oauth/${provider}`;
 };
 
-const logout = async (): Promise<BaseResponse<void>> => {
+const logout = async (): Promise<BaseResponse<void> | undefined> => {
   return await fetcher('/v1/auth/logout', {
     method: 'POST',
   });

--- a/src/api/chatbot.ts
+++ b/src/api/chatbot.ts
@@ -5,11 +5,11 @@ interface ChatbotQuestionResponse {
   answer: string;
 }
 
-const postChatbotQuestion = async (question: string): Promise<BaseResponse<ChatbotQuestionResponse>> => {
+const postChatbotQuestion = async (question: string): Promise<BaseResponse<ChatbotQuestionResponse> | undefined> => {
   return await fetcher(`/v1/chatbots`, {
     method: 'POST',
-    body: JSON.stringify({question})
+    body: JSON.stringify({ question }),
   });
-}
+};
 
 export { postChatbotQuestion };

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -1,20 +1,25 @@
 import { errors } from '@/constatns/errors';
 import { useToastStore } from '@/stores/toastStore';
 import { useUserPersistStore } from '@/stores/userPersistStore';
+import { BaseResponse } from '@/types/common/base';
 
-export async function fetcher<T>(url: string, options?: RequestInit): Promise<T> {
+export async function fetcher<T>(url: string, options?: RequestInit): Promise<BaseResponse<T> | undefined> {
   const timeout = url.includes('/v1/chatbots') ? 60000 : 5000;
-  const res = await fetch(process.env.NEXT_PUBLIC_API_URL + url, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(options?.headers ?? {}),
-    },
-    credentials: 'include',
-    signal: AbortSignal.timeout(timeout),
-  });
 
-  let responseBody: T | undefined;
+  const fetchWithAuth = async (): Promise<Response> => {
+    return fetch(`${process.env.NEXT_PUBLIC_API_URL}${url}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(options?.headers ?? {}),
+      },
+      credentials: 'include',
+      signal: AbortSignal.timeout(timeout),
+    });
+  };
+
+  let res = await fetchWithAuth();
+  let responseBody: BaseResponse<T> | undefined;
 
   try {
     responseBody = await res.json();
@@ -23,17 +28,51 @@ export async function fetcher<T>(url: string, options?: RequestInit): Promise<T>
   }
 
   if (!res.ok) {
-    if (res.status === 401) {
+    const { message } = responseBody || {};
+
+    // 토큰 만료
+    if (res.status === 401 && message === 'EXPIRED_TOKEN') {
+      try {
+        const refreshRes = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/v1/auth/refresh`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        });
+
+        if (refreshRes.ok) {
+          // 리프레시 성공 → 원래 요청 재시도
+          res = await fetchWithAuth();
+          try {
+            responseBody = await res.json();
+          } catch (error) {
+            console.error('Failed to parse JSON after refresh:', error);
+          }
+        } else {
+          // 리프레시 실패 → 로그아웃
+          useUserPersistStore.getState().cleanUser();
+          useToastStore.getState().showToast(errors.TOKEN_EXPIRED, 'error');
+          return undefined;
+        }
+      } catch (refreshError) {
+        console.error('Token refresh failed:', refreshError);
+        useToastStore.getState().showToast(errors.DEFAULT, 'error');
+        return undefined;
+      }
+    } else if (res.status === 401) {
+      // 토큰이 없는 경우
       useUserPersistStore.getState().cleanUser();
       useToastStore.getState().showToast(errors.UNAUTHORIZED, 'error');
     } else if (res.status === 403) {
+      // 승인 받지 못한 유저의 경우
       useUserPersistStore.getState().setIsApproved(false);
       useToastStore.getState().showToast(errors.FORBIDDEN, 'error');
     } else {
-      console.error(res.status);
+      console.error(`Error Status: ${res.status}`);
       useToastStore.getState().showToast(errors.DEFAULT, 'error');
     }
+
+    return undefined;
   }
 
-  return responseBody as T;
+  return responseBody;
 }

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -43,7 +43,7 @@ export async function fetcher<T>(url: string, options?: RequestInit): Promise<Ba
           // 리프레시 성공 → 원래 요청 재시도
           res = await fetchWithAuth();
           try {
-            responseBody = await res.json();
+            return await res.json();
           } catch (error) {
             console.error('Failed to parse JSON after refresh:', error);
           }

--- a/src/api/news.ts
+++ b/src/api/news.ts
@@ -16,7 +16,7 @@ const getNewsList = async ({
   cursorStandard = null,
   limit = 10,
   sort,
-}: getNewsListRequest): Promise<BaseResponse<CursorResponse<News>>> => {
+}: getNewsListRequest): Promise<CursorResponse<News>> => {
   const params = new URLSearchParams({
     ...(cursorId && { cursorId: cursorId.toString() }),
     ...(cursorStandard && { cursorStandard }),
@@ -24,11 +24,22 @@ const getNewsList = async ({
     sort,
   }).toString();
 
-  return await fetcher(`/v1/news?${params}`, { method: 'GET' });
+  const res = await fetcher<CursorResponse<News>>(`/v1/news?${params}`, { method: 'GET' });
+
+  if (!res || !res?.data) {
+    return {
+      items: [],
+      hasNext: false,
+      nextCursorStandard: null,
+      nextCursorId: null,
+    };
+  }
+
+  return res.data;
 };
 
 // 뉴스 상세 조회
-const getNewsDetail = async (newsId: string): Promise<BaseResponse<NewsDetail>> => {
+const getNewsDetail = async (newsId: string): Promise<BaseResponse<NewsDetail> | undefined> => {
   return await fetcher(`/v1/news/${newsId}`, { method: 'GET' });
 };
 
@@ -43,14 +54,25 @@ const getNewsCommentList = async ({
   cursorId = null,
   cursorStandard = null,
   limit = 10,
-}: getNewsCommentListRequest): Promise<BaseResponse<CursorResponse<PostComment>>> => {
+}: getNewsCommentListRequest): Promise<CursorResponse<PostComment>> => {
   const params = new URLSearchParams({
     ...(cursorId && { cursorId: cursorId.toString() }),
     ...(cursorStandard && { cursorStandard }),
     limit: limit.toString(),
   }).toString();
 
-  return await fetcher(`/v1/news/${newsId}/comments?${params}`, { method: 'GET' });
+  const res = await fetcher<CursorResponse<PostComment>>(`/v1/news/${newsId}/comments?${params}`, { method: 'GET' });
+
+  if (!res || !res?.data) {
+    return {
+      items: [],
+      hasNext: false,
+      nextCursorStandard: null,
+      nextCursorId: null,
+    };
+  }
+
+  return res.data;
 };
 
 // 뉴스 댓글 작성
@@ -67,7 +89,7 @@ const postNewsComment = async ({ newsId, content }: postNewsCommentRequest) => {
 };
 
 // 뉴스 좋아요 토글
-const toggleNewsLike = async (newsId: string): Promise<BaseResponse<PostLike>> => {
+const toggleNewsLike = async (newsId: string): Promise<BaseResponse<PostLike> | undefined> => {
   return await fetcher(`/v1/news/${newsId}/likes`, { method: 'PUT' });
 };
 

--- a/src/api/post.ts
+++ b/src/api/post.ts
@@ -14,18 +14,29 @@ const getNoticeList = async ({
   cursorId = null,
   cursorStandard = null,
   limit = 10,
-}: getNoticeListRequest): Promise<BaseResponse<CursorResponse<Notice>>> => {
+}: getNoticeListRequest): Promise<CursorResponse<Notice>> => {
   const params = new URLSearchParams({
     ...(cursorId && { cursorId: cursorId.toString() }),
     ...(cursorStandard && { cursorStandard }),
     limit: limit.toString(),
   }).toString();
 
-  return await fetcher(`/v1/notices?${params}`, { method: 'GET' });
+  const res = await fetcher<CursorResponse<Notice>>(`/v1/notices?${params}`, { method: 'GET' });
+
+  if (!res || !res?.data) {
+    return {
+      items: [],
+      hasNext: false,
+      nextCursorStandard: null,
+      nextCursorId: null,
+    };
+  }
+
+  return res.data;
 };
 
 // 공지 상세 조회
-const getNoticeDetail = async (noticeId: string): Promise<BaseResponse<NoticeDetail>> => {
+const getNoticeDetail = async (noticeId: string): Promise<BaseResponse<NoticeDetail> | undefined> => {
   return await fetcher(`/v1/notices/${noticeId}`, { method: 'GET' });
 };
 
@@ -40,14 +51,27 @@ const getNoticesCommentList = async ({
   cursorId = null,
   cursorStandard = null,
   limit = 10,
-}: getNoticeCommentListRequest): Promise<BaseResponse<CursorResponse<PostComment>>> => {
+}: getNoticeCommentListRequest): Promise<CursorResponse<PostComment>> => {
   const params = new URLSearchParams({
     ...(cursorId && { cursorId: cursorId.toString() }),
     ...(cursorStandard && { cursorStandard }),
     limit: limit.toString(),
   }).toString();
 
-  return await fetcher(`/v1/notices/${noticeId}/comments?${params}`, { method: 'GET' });
+  const res = await fetcher<CursorResponse<PostComment>>(`/v1/notices/${noticeId}/comments?${params}`, {
+    method: 'GET',
+  });
+
+  if (!res || !res?.data) {
+    return {
+      items: [],
+      hasNext: false,
+      nextCursorStandard: null,
+      nextCursorId: null,
+    };
+  }
+
+  return res.data;
 };
 
 // 공지 댓글 작성
@@ -64,7 +88,7 @@ const postNoticeComment = async ({ noticeId, content }: postNoticeCommentRequest
 };
 
 // 공지 좋아요 토글
-const toggleNoticeLike = async (noticeId: string): Promise<BaseResponse<PostLike>> => {
+const toggleNoticeLike = async (noticeId: string): Promise<BaseResponse<PostLike> | undefined> => {
   return await fetcher(`/v1/notices/${noticeId}/likes`, { method: 'PUT' });
 };
 

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -2,8 +2,8 @@ import { fetcher } from '@/api/fetcher';
 import { BaseResponse } from '@/types/common/base';
 import { User } from '@/types/user/user';
 
-const getUserInfo = async (): Promise<BaseResponse<User>> => {
-  return await fetcher<BaseResponse<User>>('/v1/users/info', {method: 'GET'});
+const getUserInfo = async (): Promise<BaseResponse<User> | undefined> => {
+  return await fetcher('/v1/users/info', { method: 'GET' });
 };
 
 export { getUserInfo };

--- a/src/app/(withHeader)/admin/notices/_components/AdminNoticeForm.tsx
+++ b/src/app/(withHeader)/admin/notices/_components/AdminNoticeForm.tsx
@@ -146,6 +146,7 @@ export default function AdminNoticeForm({ type }: AdminNoticeFormProps) {
         setLoading(true);
         try {
           const res = await getNoticeDetail(id.toString());
+          if (!res) return;
           const data = res.data;
           setTitle(data.title);
           setContent(data.content);

--- a/src/app/(withHeader)/news/[id]/page.tsx
+++ b/src/app/(withHeader)/news/[id]/page.tsx
@@ -23,14 +23,14 @@ export default async function NewsDetailPage({ params }: NewsDetailPageProps) {
   let news: NewsDetail | null = null;
 
   try {
-    const { data } = await fetcher<BaseResponse<NewsDetail>>(`/v1/news/${id}`, {
+    const res = await fetcher<BaseResponse<NewsDetail>>(`/v1/news/${id}`, {
       method: 'GET',
       headers: {
         Cookie: cookie,
       },
     });
 
-    if (data) news = data;
+    if (res) news = res.data.data;
   } catch (e) {
     console.error('fetch failed:', e);
   }

--- a/src/app/(withHeader)/notices/[id]/page.tsx
+++ b/src/app/(withHeader)/notices/[id]/page.tsx
@@ -24,14 +24,14 @@ export default async function NoticeDetailPage({ params }: NoticeDetailPageProps
   let notice: NoticeDetail | null = null;
 
   try {
-    const { data } = await fetcher<BaseResponse<NoticeDetail>>(`/v1/notices/${id}`, {
+    const res = await fetcher<BaseResponse<NoticeDetail>>(`/v1/notices/${id}`, {
       method: 'GET',
       headers: {
         Cookie: cookie,
       },
     });
 
-    if (data) notice = data;
+    if (res) notice = res.data.data;
   } catch (e) {
     console.error('fetch failed:', e);
   }

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -36,7 +36,7 @@ export default function Sidebar() {
 
   const handleLogout = async () => {
     const res = await logout();
-    if (res.code === 204) {
+    if (res && res.code === 204) {
       close();
       cleanUser();
       showToast('로그아웃 되었습니다.', 'success');

--- a/src/constatns/errors.ts
+++ b/src/constatns/errors.ts
@@ -1,5 +1,6 @@
 export const errors = {
-  UNAUTHORIZED: '로그아웃 되었어요. 다시 로그인해 주세요.',
+  UNAUTHORIZED: '로그인을 해야 이용할 수 있는 기능이에요.',
+  TOKEN_EXPIRED: '로그아웃 되었어요. 다시 로그인해 주세요.',
   FORBIDDEN: '인증된 사용자만 사용할 수 있는 기능이에요.',
   DEFAULT: '문제가 생겼어요. 잠시 후 다시 시도해 주세요.',
 };

--- a/src/queries/base/useInfiniteCursorQuery.ts
+++ b/src/queries/base/useInfiniteCursorQuery.ts
@@ -1,16 +1,16 @@
 import { useInfiniteQuery, UseInfiniteQueryOptions, UseInfiniteQueryResult } from '@tanstack/react-query';
 
-import { BaseResponse, CursorParam, CursorResponse } from '@/types/common/base';
+import { CursorParam, CursorResponse } from '@/types/common/base';
 
 interface UseInfiniteCursorQueryParams<TItem> {
   queryKey: string[];
-  queryFn: (params: CursorParam) => Promise<BaseResponse<CursorResponse<TItem>>>;
+  queryFn: (params: CursorParam) => Promise<CursorResponse<TItem>>;
   options?: Omit<
     UseInfiniteQueryOptions<
-      BaseResponse<CursorResponse<TItem>>, // queryFn으로 가져오는 데이터
+      CursorResponse<TItem>, // queryFn으로 가져오는 데이터
       Error,
       TItem[], // select 후 반환하는 데이터
-      BaseResponse<CursorResponse<TItem>>, // getNextPageParam의 lastPage 타입
+      CursorResponse<TItem>, // getNextPageParam의 lastPage 타입
       string[], // query key 타입
       CursorParam | null // queryFn의 pageParam 타입
     >,
@@ -23,7 +23,7 @@ export function useInfiniteCursorQuery<TItem>({
   queryFn,
   options,
 }: UseInfiniteCursorQueryParams<TItem>): UseInfiniteQueryResult<TItem[], Error> {
-  return useInfiniteQuery<BaseResponse<CursorResponse<TItem>>, Error, TItem[], string[], CursorParam | null>({
+  return useInfiniteQuery<CursorResponse<TItem>, Error, TItem[], string[], CursorParam | null>({
     queryKey,
     queryFn: ({ pageParam }) =>
       queryFn({
@@ -32,13 +32,13 @@ export function useInfiniteCursorQuery<TItem>({
       }),
     initialPageParam: null,
     getNextPageParam: (lastPage) => {
-      if (!lastPage?.data?.hasNext) return undefined;
+      if (!lastPage?.hasNext) return undefined;
       return {
-        cursorId: lastPage.data.nextCursorId,
-        cursorStandard: lastPage.data.nextCursorStandard,
+        cursorId: lastPage.nextCursorId,
+        cursorStandard: lastPage.nextCursorStandard,
       };
     },
-    select: (data) => data.pages.flatMap((page) => page.data.items),
+    select: (data) => data.pages.flatMap((page) => page.items),
     ...options,
   });
 }

--- a/src/queries/news/useNewsDetailQuery.ts
+++ b/src/queries/news/useNewsDetailQuery.ts
@@ -7,7 +7,7 @@ const useNewsDetailQuery = (id: string) => {
   return useQuery({
     queryKey: [queryKeys.news, id],
     queryFn: () => getNewsDetail(id),
-    select: (data) => data.data,
+    select: (data) => data?.data,
   });
 };
 

--- a/src/queries/news/useNewsListQuery.ts
+++ b/src/queries/news/useNewsListQuery.ts
@@ -7,7 +7,7 @@ const useNewsListQuery = (sort: 'popular' | 'latest', limit = 10) => {
   return useQuery({
     queryKey: [queryKeys.news, sort, limit],
     queryFn: () => getNewsList({ limit, sort }),
-    select: (data) => data.data.items,
+    select: (data) => data.items,
   });
 };
 

--- a/src/queries/post/useNoticeDetailQuery.ts
+++ b/src/queries/post/useNoticeDetailQuery.ts
@@ -7,7 +7,7 @@ const useNoticeDetailQuery = (id: string) => {
   return useQuery({
     queryKey: [queryKeys.notice, id],
     queryFn: () => getNoticeDetail(id),
-    select: (data) => data.data,
+    select: (data) => data?.data,
   });
 };
 

--- a/src/queries/post/useNoticeListInfinityQuery.ts
+++ b/src/queries/post/useNoticeListInfinityQuery.ts
@@ -3,17 +3,17 @@ import { UseInfiniteQueryOptions } from '@tanstack/react-query';
 import { getNoticeList } from '@/api/post';
 import { queryKeys } from '@/constatns/keys';
 import { useInfiniteCursorQuery } from '@/queries/base/useInfiniteCursorQuery';
-import { BaseResponse, CursorParam, CursorResponse } from '@/types/common/base';
+import { CursorParam, CursorResponse } from '@/types/common/base';
 import { Notice } from '@/types/post/notice';
 
 interface UseNoticeListInfinityQueryParams {
   limit?: number;
   options?: Omit<
     UseInfiniteQueryOptions<
-      BaseResponse<CursorResponse<Notice>>, // queryFn으로 가져오는 데이터
+      CursorResponse<Notice>, // queryFn으로 가져오는 데이터
       Error,
       Notice[], // select 후 반환하는 데이터
-      BaseResponse<CursorResponse<Notice>>, // getNextPageParam의 lastPage 타입
+      CursorResponse<Notice>, // getNextPageParam의 lastPage 타입
       string[], // query key 타입
       CursorParam | null // queryFn의 pageParam 타입
     >,


### PR DESCRIPTION
### Description
- 토큰 만료 후 refresh 후 다시 API 요청 보내도록 구현

### Related Issues
- Resolves #81

### Changes Made
1. 토큰 리프레시 구현
2. fetcher에서 undefined를 리턴할 수 있도록 하여 fetcher를 호출하는 부분에서 에러처리를 강제하도록 구현
