### PR TITLE
Fix: 홈 화면 관련 이슈 수정

### DIFF
--- a/src/components/common/atoms/SafeImage/SafeImage.tsx
+++ b/src/components/common/atoms/SafeImage/SafeImage.tsx
@@ -49,6 +49,7 @@ export function SafeImage({ src, alt, className = '', fallbackSrc, fill, width, 
 
     return (
       <div
+        {...props}
         style={fill ? {} : { width, height }}
         className={`w-full h-full bg-gray-200 flex items-center justify-center text-gray-500 text-xs ${className}`}
       ></div>

--- a/src/components/home/pages/HomePage/HomePage.tsx
+++ b/src/components/home/pages/HomePage/HomePage.tsx
@@ -10,7 +10,7 @@ import { NoticesPanel } from '@/components/home/organisms/NoticesPanel';
 
 export function HomePage() {
   return (
-    <div className="min-h-screen bg-neutral-50">
+    <div className="min-h-app bg-neutral-50">
       <div className="max-w-md mx-auto px-4 py-6">
         {/* 챗봇 */}
         <div className="bg-white rounded-3xl p-6 text-white relative overflow-hidden shadow-sm">


### PR DESCRIPTION
### Description
- 홈 화면 관련 이슈 수정

### Related Issues
- Resolves #147

### Changes Made
1. 홈 화면의 높이를 min-h-screen -> min-h-app으로 수정하여 헤더가 잘리지 않도록 수정
2. 홈 화면에서 이미지가 없을 경우 fallback에서 onClick이벤트를 안 받던 이슈 수정
