### PR TITLE
Fix: WikiDetail에서 뒤로가기로 다시 WikiMain으로 가는 경우 페이지 스크롤이 불가한 이슈 수정

### DIFF
--- a/src/widgets/wiki/sections/WikiEditor/WikiEditor.scss
+++ b/src/widgets/wiki/sections/WikiEditor/WikiEditor.scss
@@ -1,10 +1,6 @@
 body {
   --tt-toolbar-height: 44px;
   --tt-theme-text: var(--color-neutral-900);
-
-  .dark & {
-    --tt-theme-text: var(--tt-gray-dark-900);
-  }
 }
 
 body {
@@ -14,18 +10,6 @@ body {
   font-weight: 400;
   font-style: normal;
   padding: 0;
-}
-
-html,
-body,
-#root,
-#app {
-  height: 100%;
-  background-color: var(--tt-bg-color);
-}
-
-body {
-  overflow: hidden;
 }
 
 .tiptap.ProseMirror {


### PR DESCRIPTION
### Description
- WikiDetail에서 뒤로가기로 다시 WikiMain으로 가는 경우 페이지 스크롤이 불가한 이슈

### Related Issues
- Resolves #196

### Changes Made
1. WikiEditor.scss에서 불필요하게 body 크기를 늘리는 이슈 수정