### PR TITLE
Fix: 위키 생성 시 content-type을 명시적으로 설정

### DIFF
--- a/src/features/wiki/api/wiki.ts
+++ b/src/features/wiki/api/wiki.ts
@@ -74,5 +74,9 @@ interface postWikiRequest {
 }
 
 export const postWiki = async ({ title }: postWikiRequest) => {
-  return await fetcher(`/v1/wikis`, { method: 'POST', body: JSON.stringify({ title }) });
+  return await fetcher(`/v1/wikis`, {
+    method: 'POST',
+    body: JSON.stringify({ title }),
+    headers: { 'Content-Type': 'application/json' },
+  });
 };


### PR DESCRIPTION
### Description
- Wiki 생성 시 Content-Type이 자동으로 들어가지 않아 명시적으로 추가했습니다.

### Related Issues
- Resolves #223

### Checklist
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.