### PR TITLE
Feat: 공지 리스트 가상 스크롤 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tailwindcss/typography": "0.5.16",
     "@tanstack/react-query": "5.74.7",
     "@tanstack/react-query-devtools": "5.75.1",
+    "@tanstack/react-virtual": "^3.13.12",
     "@tiptap/extension-collaboration": "2.12.0",
     "@tiptap/extension-collaboration-cursor": "^2.22.3",
     "@tiptap/extension-highlight": "2.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: 5.75.1
         version: 5.75.1(@tanstack/react-query@5.74.7(react@19.1.0))(react@19.1.0)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.12
+        version: 3.13.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tiptap/extension-collaboration':
         specifier: 2.12.0
         version: 2.12.0(@tiptap/core@2.14.0(@tiptap/pm@2.12.0))(@tiptap/pm@2.12.0)(y-prosemirror@1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.40.0)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27))
@@ -2021,6 +2024,15 @@ packages:
     resolution: {integrity: sha512-u4o/RIWnnrq26orGZu2NDPwmVof1vtAiiV6KYUXd49GuK+8HX+gyxoAYqIaZogvCE1cqOuZAhQKcrKGYGkrLxg==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-virtual@3.13.12':
+    resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.13.12':
+    resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -7611,6 +7623,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.74.7
       react: 19.1.0
+
+  '@tanstack/react-virtual@3.13.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.12
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@tanstack/virtual-core@3.13.12': {}
 
   '@testing-library/dom@10.4.0':
     dependencies:

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -139,3 +139,6 @@
     margin-top: 60px;
 }
 
+.virtualized-item {
+    will-change: transform;
+}

--- a/src/widgets/post/components/NoticeListItem/NoticeListItem.tsx
+++ b/src/widgets/post/components/NoticeListItem/NoticeListItem.tsx
@@ -1,5 +1,7 @@
 import { ChevronRight } from 'lucide-react';
 
+import { memo } from 'react';
+
 import { Notice } from '@/entities/post/notice';
 import { formatTime, isRecent } from '@/shared/lib/utils/times';
 
@@ -10,7 +12,7 @@ type NoticeItemProps = {
   notice: Notice;
 };
 
-export function NoticeListItem({ notice }: NoticeItemProps) {
+export function NoticeListItemComponent({ notice }: NoticeItemProps) {
   const renderAvatar = () => {
     if (notice.author.includes('helper.ryan')) {
       return <SafeImage src={helperRyan} alt="helper.ryan(헬퍼라이언)" width={64} height={64} />;
@@ -56,3 +58,5 @@ export function NoticeListItem({ notice }: NoticeItemProps) {
     </div>
   );
 }
+
+export const NoticeListItem = memo(NoticeListItemComponent);


### PR DESCRIPTION
### Description
- 공지 리스트 무한 스크롤에서 가상 스크롤을 적용했습니다.
- 타 리스트 대비 아이템 수가 많아 우선적으로 도입했습니다.

### Related Issues
- Resolves #251

### Changes Made
1. tanstack virtual을 사용한 가상 스크롤 구현
2. NoticeListItem 메모이제이션으로 성능 최적화

### Checklist
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.

### Additional Notes
관련 문서
https://github.com/100-hours-a-week/20-real-fe/issues/252


