### PR TITLE
Refacot: NewsDetail Page SSR 전환

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prepare": "husky",
     "vitest-coverage": "vitest run --coverage",
     "playwright:prod": "NODE_ENV=production npx playwright test",
-    "playwright:dev": "npx playwright test"
+    "playwright:dev": "npx playwright test",
+    "build:analyze": "ANALYZE=true next build"
   },
   "dependencies": {
     "@floating-ui/react": "0.27.9",

--- a/src/shared/lib/utils/getApiData.ts
+++ b/src/shared/lib/utils/getApiData.ts
@@ -1,0 +1,38 @@
+import { cookies } from 'next/headers';
+
+import { fetcher } from '@/shared/lib/utils/fetcher';
+
+type ErrorResponse = {
+  code: string;
+  message: string;
+};
+
+export async function getApiData<T>(
+  url: string,
+  options?: RequestInit & { withAuth?: boolean },
+): Promise<{ data?: T; error?: ErrorResponse }> {
+  try {
+    const cookieStore = await cookies();
+    const headers: HeadersInit = {
+      ...(options?.headers ?? {}),
+      ...(options?.withAuth
+        ? { Cookie: cookieStore.toString() } // SSR 쿠키 전달
+        : {}),
+    };
+
+    const response = await fetcher<T>(url, {
+      ...options,
+      headers,
+    });
+
+    return { data: response.data };
+  } catch (err) {
+    const appErr = err as Error & { code?: string };
+    return {
+      error: {
+        code: appErr.code ?? 'UNKNOWN',
+        message: appErr.message,
+      },
+    };
+  }
+}

--- a/src/shared/ui/section/MarkdownViewerServer/MarkdownViewerServer.tsx
+++ b/src/shared/ui/section/MarkdownViewerServer/MarkdownViewerServer.tsx
@@ -1,0 +1,76 @@
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize from 'rehype-sanitize';
+import remarkBreaks from 'remark-breaks';
+import remarkGfm from 'remark-gfm';
+
+import Markdown from 'react-markdown';
+import { PrismLight } from 'react-syntax-highlighter';
+
+import { cn } from '@/shared/lib/utils/cn';
+import { normalizeMarkdown } from '@/shared/lib/utils/normalizeMarkdown';
+
+interface MarkdownViewerServerProps {
+  text: string;
+  className?: string;
+}
+
+export default function MarkdownViewerServer({ text, className }: MarkdownViewerServerProps) {
+  return (
+    <div className={cn(`text-black text-sm/6 break-all`, className)}>
+      <Markdown
+        remarkPlugins={[remarkGfm, remarkBreaks]}
+        rehypePlugins={[rehypeRaw, rehypeSanitize]}
+        components={{
+          h1: (props) => <h1 className="text-2xl font-bold mt-6 pb-2 mb-2 border-b-1 border-gray-300" {...props} />,
+          h2: (props) => <h2 className="text-xl font-bold mt-5 pb-2 mb-2 border-b-1 border-gray-300" {...props} />,
+          h3: (props) => <h3 className="text-lg font-semibold mt-4 mb-2" {...props} />,
+          p: (props) => <p className="text-sm leading-6 mb-2" {...props} />,
+          ul: (props) => <ul className="list-disc list-outside ml-5 mb-2" {...props} />,
+          ol: (props) => <ol className="list-decimal list-outside ml-5 mb-2" {...props} />,
+          li: (props) => <li className="ml-2" {...props} />,
+          a: (props) => (
+            <a
+              className="text-blue-600 underline hover:text-blue-800 break-words max-w-full inline-block mb-2"
+              target="_blank"
+              rel="noopener noreferrer"
+              {...props}
+            />
+          ),
+          strong: (props) => <strong className="font-semibold text-black mb-2" {...props} />,
+          blockquote: (props) => (
+            <blockquote className="border-l-4 border-gray-300 pl-4 italic text-gray-600 my-4" {...props} />
+          ),
+          table: (props) => (
+            <div className="overflow-x-auto">
+              <table className="table-auto border border-gray-600 border-collapse w-full min-w-[600px]" {...props} />
+            </div>
+          ),
+          th: (props) => <th className="border border-gray-600 px-2 py-1 bg-gray-100 text-left" {...props} />,
+          td: (props) => <td className="border border-gray-600 px-2 py-1 whitespace-pre-line break-words" {...props} />,
+          aside: (props) => <aside {...props} />,
+          tr: (props) => <tr className="even:bg-gray-50" {...props} />,
+          code: ({ children, className }) => {
+            const match = /language-(\w+)/.exec(className || '');
+            const codeString = String(children).replace(/\n$/, '');
+
+            if (match) {
+              return (
+                <PrismLight language={match[1]} PreTag="div">
+                  {codeString}
+                </PrismLight>
+              );
+            }
+
+            return (
+              <code className="bg-gray-100 px-1 py-0.5 rounded text-xs font-mono text-primary-700 mb-2">
+                {codeString}
+              </code>
+            );
+          },
+        }}
+      >
+        {normalizeMarkdown(text)}
+      </Markdown>
+    </div>
+  );
+}

--- a/src/shared/ui/section/MarkdownViewerServer/index.ts
+++ b/src/shared/ui/section/MarkdownViewerServer/index.ts
@@ -1,0 +1,1 @@
+export * from './MarkdownViewerServer';

--- a/src/widgets/post/components/PostSummary/PostSummary.tsx
+++ b/src/widgets/post/components/PostSummary/PostSummary.tsx
@@ -1,4 +1,4 @@
-import { MarkdownViewer } from '../../../../shared/ui/section/MarkdownViewer';
+import MarkdownViewerServer from '@/shared/ui/section/MarkdownViewerServer/MarkdownViewerServer';
 
 interface PostSummaryProps {
   summary: string;
@@ -14,7 +14,7 @@ export function PostSummary({ summary }: PostSummaryProps) {
           </svg>
         </div>
         <div className="flex-1 text-sm text-gray-700">
-          <MarkdownViewer text={summary} />
+          <MarkdownViewerServer text={summary} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Description
- NewsDetail Page SSR 전환

### Related Issues
- Resolves #273

### Changes Made
1. 뉴스 상세 페이지 SSR 전환
2. MarkdownViewer의 번들사이즈가 커 RSC 컴포넌트 구현

### Checklist
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.

### Additional Notes
- 해당 페이지 LCP 15% 개선

