### PR TITLE
Fix: 위키 문서 당 최대 15000자 제한

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@tiptap/extension-text-align": "2.12.0",
     "@tiptap/extension-typography": "2.12.0",
     "@tiptap/extension-underline": "2.12.0",
+    "@tiptap/extensions": "^3.0.7",
     "@tiptap/pm": "2.12.0",
     "@tiptap/react": "2.12.0",
     "@tiptap/starter-kit": "2.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@tiptap/extension-underline':
         specifier: 2.12.0
         version: 2.12.0(@tiptap/core@2.14.0(@tiptap/pm@2.12.0))
+      '@tiptap/extensions':
+        specifier: ^3.0.7
+        version: 3.0.7(@tiptap/core@2.14.0(@tiptap/pm@2.12.0))(@tiptap/pm@2.12.0)
       '@tiptap/pm':
         specifier: 2.12.0
         version: 2.12.0
@@ -2244,6 +2247,12 @@ packages:
     resolution: {integrity: sha512-u95lrUCesw1SN3BXY4xrgfSuxtoCYmJ9uaU7IVVOu0zVsDFtLlOa82kd63KVF+URL0kMdO+FBmvdS6d8Era70Q==}
     peerDependencies:
       '@tiptap/core': ^2.7.0
+
+  '@tiptap/extensions@3.0.7':
+    resolution: {integrity: sha512-GkXX5l7Q/543BKsC14j8M3qT+75ILb7138zy7cZoHm/s1ztV1XTknpEswBZIRZA9n6qq+Wd9g5qkbR879s6xhA==}
+    peerDependencies:
+      '@tiptap/core': ^3.0.7
+      '@tiptap/pm': ^3.0.7
 
   '@tiptap/pm@2.12.0':
     resolution: {integrity: sha512-TNzVwpeNzFfHAcYTOKqX9iU4fRxliyoZrCnERR+RRzeg7gWrXrCLubQt1WEx0sojMAfznshSL3M5HGsYjEbYwA==}
@@ -7817,6 +7826,11 @@ snapshots:
   '@tiptap/extension-underline@2.12.0(@tiptap/core@2.14.0(@tiptap/pm@2.12.0))':
     dependencies:
       '@tiptap/core': 2.14.0(@tiptap/pm@2.12.0)
+
+  '@tiptap/extensions@3.0.7(@tiptap/core@2.14.0(@tiptap/pm@2.12.0))(@tiptap/pm@2.12.0)':
+    dependencies:
+      '@tiptap/core': 2.14.0(@tiptap/pm@2.12.0)
+      '@tiptap/pm': 2.12.0
 
   '@tiptap/pm@2.12.0':
     dependencies:

--- a/src/widgets/wiki/sections/WikiEditor/WikiEditor.tsx
+++ b/src/widgets/wiki/sections/WikiEditor/WikiEditor.tsx
@@ -14,6 +14,7 @@ import { TaskList } from '@tiptap/extension-task-list';
 import { TextAlign } from '@tiptap/extension-text-align';
 import { Typography } from '@tiptap/extension-typography';
 import { Underline } from '@tiptap/extension-underline';
+import { CharacterCount } from '@tiptap/extensions';
 import { EditorContent, EditorContext, useEditor } from '@tiptap/react';
 import { StarterKit } from '@tiptap/starter-kit';
 
@@ -75,6 +76,9 @@ export function WikiEditor({ wiki }: WikiEditorProps) {
       TaskItem.configure({ nested: true }),
       Image,
       Typography,
+      CharacterCount.configure({
+        limit: 15000,
+      }),
       Collaboration.configure({
         document: doc,
       }),


### PR DESCRIPTION
### Description
- 위키 문서 당 최대 15000자 제한

### Related Issues
- Resolves #283

### Changes Made
1. 웹소켓에서 문자 인코딩 시 일정 길이 이상일 경우 crash 나는 이슈 임시 방어